### PR TITLE
Fixed bug in INP export code regarding MeshGroup.

### DIFF
--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -19,6 +19,8 @@ import std.typecons: tuple, Tuple;
 import std.stdio;
 import nijilive.core.nodes.utils;
 import std.algorithm.searching;
+import std.algorithm;
+import std.string;
 
 package(nijilive) {
     void inInitMeshGroup() {
@@ -347,7 +349,21 @@ public:
 
 
         foreach (param; params) {
+            ParameterBinding[Resource][string] trsBindings;
+            void extractTRSBindings(Parameter param) {
+                foreach (binding; param.bindings) {
+                    trsBindings[binding.getTarget.name][binding.getTarget.target] = binding;
+                }
+            } 
+            extractTRSBindings(param);
+
             void applyTranslation(Node node, Parameter param, vec2u keypoint, vec2 ofs) {
+                foreach (name; ["t.x", "t.y", "r.z", "s.x", "s.y"].map!((x)=> "transform.%s".format(x))) {
+                    if (name in trsBindings && node in trsBindings[name]) {
+                        trsBindings[name][node].apply(keypoint, ofs);
+                    }
+                }
+                /*
                 auto TXBind = param.getBinding(node, "transform.t.x");
                 auto TYBind = param.getBinding(node, "transform.t.y");
                 auto RZBind = param.getBinding(node, "transform.r.z");
@@ -358,6 +374,7 @@ public:
                 if (RZBind) RZBind.apply(keypoint, ofs);
                 if (SXBind) SXBind.apply(keypoint, ofs);
                 if (SYBind) SYBind.apply(keypoint, ofs);
+                */
             }
 
             void transferChildren(Node node, int x, int y) {

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -363,18 +363,6 @@ public:
                         trsBindings[name][node].apply(keypoint, ofs);
                     }
                 }
-                /*
-                auto TXBind = param.getBinding(node, "transform.t.x");
-                auto TYBind = param.getBinding(node, "transform.t.y");
-                auto RZBind = param.getBinding(node, "transform.r.z");
-                auto SXBind = param.getBinding(node, "transform.s.x");
-                auto SYBind = param.getBinding(node, "transform.s.y");
-                if (TXBind) TXBind.apply(keypoint, ofs);
-                if (TYBind) TYBind.apply(keypoint, ofs);
-                if (RZBind) RZBind.apply(keypoint, ofs);
-                if (SXBind) SXBind.apply(keypoint, ofs);
-                if (SYBind) SYBind.apply(keypoint, ofs);
-                */
             }
 
             void transferChildren(Node node, int x, int y) {
@@ -403,14 +391,6 @@ public:
 
                     auto vertices = drawable.vertices;
                     mat4 matrix = drawable.transform.matrix;
-                    /*
-                    writefln("%d, %d: %s: t=(%.2f, %.2f), r=%.2f,s=(%.2f, %.2f)", 
-                        x, y, name, transform.translation.x, transform.translation.y, 
-                        transform.rotation.z, transform.scale.x, transform.scale.y);
-                    writefln("%d, %d:     %s: t=(%.2f, %.2f), r=%.2f,s=(%.2f, %.2f)", 
-                        x, y, node.name, node.transform.translation.x, node.transform.translation.y, 
-                        node.transform.rotation.z, node.transform.scale.x, node.transform.scale.y);
-                    */
 
                     auto nodeBinding = cast(DeformationParameterBinding)param.getOrAddBinding(node, "deform");
                     auto nodeDeform = nodeBinding.values[x][y].vertexOffsets.dup;

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -437,7 +437,6 @@ public:
                 auto deformBinding = cast(DeformationParameterBinding)binding;
                 assert(deformBinding !is null);
                 Node target = deformBinding.targetNode;
-//                writefln("%s: deform by %s", name, param.name);
 
                 for (int x = 0; x < param.axisPoints[0].length; x ++) {
                     for (int y = 0; y < param.axisPoints[1].length; y ++) {


### PR DESCRIPTION
MeshGroup is not exported properly if translation is set for children of meshgroup node.
This patch fixed the problem.