### PR TITLE
Introduce "pinToMesh" option.

### DIFF
--- a/source/nijilive/core/nodes/composite/dcomposite.d
+++ b/source/nijilive/core/nodes/composite/dcomposite.d
@@ -134,7 +134,8 @@ public:
         foreach (child; children) {
             setIgnorePuppetRecurse(child, ignorePuppet);
         }
-        puppet.rescanNodes();
+        if (puppet !is null)
+            puppet.rescanNodes();
     }
 
     void drawSelf(bool isMask = false)() {
@@ -487,13 +488,15 @@ public:
     override
     void setupChild(Node node) {
         setIgnorePuppetRecurse(node, true);
-        puppet.rescanNodes();
+        if (puppet !is null)
+            puppet.rescanNodes();
     }
 
     override
     void releaseChild(Node node) {
         setIgnorePuppetRecurse(node, false);
-        puppet.rescanNodes();
+        if (puppet !is null)
+            puppet.rescanNodes();
     }
 
     override

--- a/source/nijilive/core/nodes/drawable.d
+++ b/source/nijilive/core/nodes/drawable.d
@@ -93,7 +93,7 @@ protected:
     Tuple!(vec2[], mat4*, bool) nodeAttachProcessor(Node node, vec2[] origVertices, vec2[] origDeformation, mat4* origTransform) {
         bool changed = false;
         vec2 nodeOrigin = (this.transform.matrix.inverse * vec4(node.transform.translation, 1));
-//        writefln("%s: nodeOrigin=%s", name, nodeOrigin);
+//        writefln("%s-->%s: nodeOrigin=%s", name, node.name, nodeOrigin);
         if (node !in attachedIndex)
             attachedIndex[node] = findSurroundingTriangle(nodeOrigin, this.data);
         auto triangle = attachedIndex[node];
@@ -698,15 +698,14 @@ public:
     void setupChild(Node node) {
         super.setupChild(node);
         if (node.pinToMesh) {
-            node.preProcessFilters  = node.preProcessFilters.removeByValue(&nodeAttachProcessor);
-            if (node.postProcessFilters.countUntil(&nodeAttachProcessor) == -1)
-                node.postProcessFilters ~= &nodeAttachProcessor;
+            if (node.preProcessFilters.countUntil(&nodeAttachProcessor) == -1)
+                node.preProcessFilters ~= &nodeAttachProcessor;
         }
     }
 
     override
     void releaseChild(Node node) {
-        node.preProcessFilters = node.preProcessFilters.removeByValue(&this.nodeAttachProcessor);
+        node.preProcessFilters = node.preProcessFilters.removeByValue(&nodeAttachProcessor);
         super.releaseChild(node);
     }
 

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -285,7 +285,7 @@ public:
 
     override
     void setupChild(Node child) {
- 
+        super.setupChild(child);
         void setGroup(Node node) {
             auto drawable = cast(Drawable)node;
             auto group    = cast(MeshGroup)node;
@@ -335,6 +335,7 @@ public:
             }
         }
         unsetGroup(child);
+        super.releaseChild(child);
     }
 
     void applyDeformToChildren(Parameter[] params) {

--- a/source/nijilive/math/triangle.d
+++ b/source/nijilive/math/triangle.d
@@ -117,8 +117,8 @@ mat3 calculateAffineTransform(vec2[] vertices, int[] triangle, vec2[] deform) {
     auto p5 = p2 + deform[triangle[2]];
 
     mat3 transformed = mat3(
-        p3.x, p4.x, p4.x,
-        p3.y, p4.y, p4.y,
+        p3.x, p4.x, p5.x,
+        p3.y, p4.y, p5.y,
         1.0f, 1.0f, 1.0f);
 
     mat3 affineTransform = transformed * original.inverse();

--- a/source/nijilive/math/triangle.d
+++ b/source/nijilive/math/triangle.d
@@ -1,9 +1,12 @@
 module nijilive.math.triangle;
 import nijilive.math;
 import nijilive.core.meshdata;
+import nijilive.core.nodes.defstack;
 import inmath;
 import std.math;
 import std.algorithm;
+import std.array : array;
+import std.conv : to;
 
 
 bool isPointInTriangle(vec2 pt, vec2[3] triangle) {
@@ -97,4 +100,65 @@ vec2 calcOffsetInTriangleCoords(vec2 pt, ref MeshData bindingMesh, ref int[] tri
 
         return result;
     }
+}
+
+private {
+mat3 calculateAffineTransform(vec2[] vertices, int[] triangle, vec2[] deform) {
+    auto p0 = vertices[triangle[0]];
+    auto p1 = vertices[triangle[1]];
+    auto p2 = vertices[triangle[2]];
+    mat3 original = mat3(
+        p0.x, p1.x, p2.x,
+        p0.y, p1.y, p2.y,
+        1.0f, 1.0f, 1.0f
+    );
+    auto p3 = p0 + deform[triangle[0]];
+    auto p4 = p1 + deform[triangle[1]];
+    auto p5 = p2 + deform[triangle[2]];
+
+    mat3 transformed = mat3(
+        p3.x, p4.x, p4.x,
+        p3.y, p4.y, p4.y,
+        1.0f, 1.0f, 1.0f);
+
+    mat3 affineTransform = transformed * original.inverse();
+    return affineTransform;
+}
+
+vec2 applyAffineTransform(mat3 transform, vec2 point) {
+    vec3 pointHomogeneous = vec3(point, 1.0);
+    vec3 transformedPointHomogeneous = transform * pointHomogeneous;
+    return transformedPointHomogeneous.xy;
+}
+
+float calculateAngle(vec2 A, vec2 B) {
+    return atan2(B.y - A.y, B.x - A.x);
+}
+}
+
+bool nlCalculateTransformInTriangle(vec2[] vertices, int[] triangle, vec2[] deform, vec2 target, 
+        out vec2 target_prime, out float rotationAngle_vert, out float rotationAngle_horz) {
+    mat3 affineTransform = calculateAffineTransform(vertices, triangle, deform);
+    target_prime = applyAffineTransform(affineTransform, target);
+
+    // Vertical unit vector rotation
+    vec2 vert = vec2(0, 1);
+    vec2 target_vert = target + vert;
+    vec2 target_vert_prime = applyAffineTransform(affineTransform, target_vert);
+
+    // Horizontal unit vector rotation
+    vec2 horz = vec2(1, 0);
+    vec2 target_horz = target + horz;
+    vec2 target_horz_prime = applyAffineTransform(affineTransform, target_horz);
+
+    // Calculate angles from above vectors.
+    float originalAngle_vert = calculateAngle(target, target_vert);
+    float transformedAngle_vert = calculateAngle(target_prime, target_vert_prime);
+    rotationAngle_vert = transformedAngle_vert - originalAngle_vert;
+
+    float originalAngle_horz = calculateAngle(target, target_horz);
+    float transformedAngle_horz = calculateAngle(target_prime, target_horz_prime);
+    rotationAngle_horz = transformedAngle_horz - originalAngle_horz;
+
+    return true;
 }


### PR DESCRIPTION
"pinToMesh" option enables parent Drawable to modify origin of target node according to the change of parent's mesh.
This option is similar with the behavior of MeshGroup, but any Drawable can move the children by this option.
This is useful to attach items to INP file in nijiexpose program.