### PR TITLE
Improve gitver experience

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,7 +9,8 @@ dependency "i2d-opengl" version="~>1.0.0"
 dependency "fghj" version="~>1.0.2"
 versions "GL_32" "GL_ARB_gl_spirv" "GL_KHR_blend_equation_advanced" "GL_ARB_texture_filter_anisotropic"
 stringImportPaths "shaders/"
-preBuildCommands "dub run gitver -- --prefix IN --file source/nijilive/ver.d --mod nijilive.ver --appname nijilive"
+preBuildCommands "sh update-gitver.sh nijilive IN" platform="posix"
+preBuildCommands "dub run gitver -- --prefix IN --file source/nijilive/ver.d --mod nijilive.ver --appname nijilive" platform="windows"
 
 
 configuration "full" {

--- a/update-gitver.sh
+++ b/update-gitver.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+dub run gitver -- --prefix $2 --file source/$1/ver.d.new --mod $1.ver --appname $1
+cmp source/$1/ver.d source/$1/ver.d.new &>/dev/null && rm source/$1/ver.d.new && exit 0 || true
+mv -f source/$1/ver.d.new source/$1/ver.d


### PR DESCRIPTION
Wrap gitver in a script that only replaces ver.d if its contents changed. This avoids triggering a full rebuild every time, even if nothing changed.