### PR TITLE
Fixed confused implementation of copyFrom method.

### DIFF
--- a/source/nijilive/core/nodes/composite/dcomposite.d
+++ b/source/nijilive/core/nodes/composite/dcomposite.d
@@ -633,8 +633,8 @@ public:
     }
 
     override
-    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
-        super.copyFrom(src, inPlace, deepCopy);
+    void copyFrom(Node src, bool clone = false, bool deepCopy = true) {
+        super.copyFrom(src, clone, deepCopy);
 
         textures = [null, null, null];
         initialized = false;

--- a/source/nijilive/core/nodes/deformer/path.d
+++ b/source/nijilive/core/nodes/deformer/path.d
@@ -365,8 +365,8 @@ public:
     }
 
     override
-    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
-        super.copyFrom(src, inPlace, deepCopy);
+    void copyFrom(Node src, bool clone = false, bool deepCopy = true) {
+        super.copyFrom(src, clone, deepCopy);
 
         if (auto pathDeformer = cast(PathDeformer)src) {
             clearCache();

--- a/source/nijilive/core/nodes/drawable.d
+++ b/source/nijilive/core/nodes/drawable.d
@@ -584,14 +584,14 @@ public:
     }
 
     override
-    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
+    void copyFrom(Node src, bool clone = false, bool deepCopy = true) {
         bool autoResizedMesh = false;
         auto dcomposite = cast(DynamicComposite)src;
         if (dcomposite !is null) {
             autoResizedMesh = dcomposite.autoResizedMesh;
             dcomposite.autoResizedMesh = false;
         }
-        super.copyFrom(src, inPlace, deepCopy);
+        super.copyFrom(src, clone, deepCopy);
         if (auto drawable = cast(Drawable)src) {
             MeshData newData;
             newData.vertices = drawable.data.vertices.dup;

--- a/source/nijilive/core/nodes/drivers/simplephysics.d
+++ b/source/nijilive/core/nodes/drivers/simplephysics.d
@@ -646,8 +646,8 @@ public:
     vec2 getOutputScale() { return outputScale * offsetOutputScale; }
 
     override
-    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
-        super.copyFrom(src, inPlace, deepCopy);
+    void copyFrom(Node src, bool clone = false, bool deepCopy = true) {
+        super.copyFrom(src, clone, deepCopy);
 
         if (auto sphysics = cast(SimplePhysics)src) {
             modelType_ = sphysics.modelType_;

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -538,8 +538,8 @@ public:
     }
 
     override
-    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
-        super.copyFrom(src, inPlace, deepCopy);
+    void copyFrom(Node src, bool clone = false, bool deepCopy = true) {
+        super.copyFrom(src, clone, deepCopy);
 
         if (auto mgroup = cast(MeshGroup)src) {
             dynamic = mgroup.dynamic;

--- a/source/nijilive/core/nodes/part/package.d
+++ b/source/nijilive/core/nodes/part/package.d
@@ -910,12 +910,12 @@ public:
     }
 
     override
-    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
+    void copyFrom(Node src, bool clone = false, bool deepCopy = true) {
         if ((cast(DynamicComposite)src) !is null &&
             (cast(DynamicComposite)this) is null) {
                 deepCopy = false;
         }
-        super.copyFrom(src, inPlace, deepCopy);
+        super.copyFrom(src, clone, deepCopy);
 
         if (auto part = cast(Part)src) {
             offsetMaskThreshold = 0;


### PR DESCRIPTION
- bool inPlace argument is changed to clone, and not replace original node.
- reparent method has optional "ignoreTransform" arguments. if set to true, transform parameter is not altered. This is useful when you want to set localTransform directly from external code.