### PR TITLE
Added NodeFilter, and implemented export feature for PathDeformer.

### DIFF
--- a/source/nijilive/core/nodes/deformer/path.d
+++ b/source/nijilive/core/nodes/deformer/path.d
@@ -352,6 +352,24 @@ public:
         meshCaches.clear();
     }
 
+    void applyDeformToChildren(Parameter[] params) {
+        if (driver !is null)
+            return;
+
+        void prepare(vec2[] deformation) {
+            if (vertices.length >= 2) {
+                deform(zip(vertices(), deformation).map!((t) => t[0] + t[1] ).array);
+            }
+            inverseMatrix = globalTransform.matrix.inverse;
+        }
+
+        bool transfer() { return false; }
+
+        _applyDeformToChildren(&deformChildren, &prepare, &transfer, params);
+
+        rebuffer([]);
+    }
+
     override
     void centralize() {
         foreach (child; children) {

--- a/source/nijilive/core/nodes/deformer/path.d
+++ b/source/nijilive/core/nodes/deformer/path.d
@@ -33,7 +33,8 @@ package(nijilive) {
 
 
 @TypeId("PathDeformer")
-class PathDeformer : Deformable {
+class PathDeformer : Deformable, NodeFilter {
+    mixin NodeFilterMixin;
 protected:
     mat4 inverseMatrix;
     PhysicsDriver _driver;

--- a/source/nijilive/core/nodes/filter.d
+++ b/source/nijilive/core/nodes/filter.d
@@ -1,11 +1,14 @@
 module nijilive.core.nodes.filter;
 import nijilive.core.nodes;
 import nijilive.core.nodes.utils;
+import nijilive.core.param;
+public import std.format;
 
 interface NodeFilter {
     void captureTarget(Node target);
     void releaseTarget(Node target);
     void dispose();
+    void applyDeformToChildren(Parameter[] params);
 }
 
 mixin template NodeFilterMixin() {
@@ -27,5 +30,120 @@ mixin template NodeFilterMixin() {
             releaseChild(t);
         }
         children_ref.length = 0;
+    }
+
+    void _applyDeformToChildren(Node.Filter filterChildren, void delegate(vec2[]) prepare, bool delegate() transferCondition, Parameter[] params) {
+        foreach (param; params) {
+            ParameterBinding[Resource][string] trsBindings;
+            void extractTRSBindings(Parameter param) {
+                foreach (binding; param.bindings) {
+                    trsBindings[binding.getTarget.name][binding.getTarget.target] = binding;
+                }
+            } 
+            extractTRSBindings(param);
+
+            void applyTranslation(Node node, Parameter param, vec2u keypoint, vec2 ofs) {
+                foreach (name; ["t.x", "t.y", "r.z", "s.x", "s.y"].map!((x)=> "transform.%s".format(x))) {
+                    if (name in trsBindings && node in trsBindings[name]) {
+                        trsBindings[name][node].apply(keypoint, ofs);
+                    }
+                }
+            }
+
+            void transferChildren(Node node, int x, int y) {
+                auto drawable = cast(Deformable)node;
+                auto composite = cast(Composite)node;
+                bool isDeformable = drawable !is null;
+                bool isComposite = composite !is null && composite.propagateMeshGroup;
+                bool mustPropagate = node.mustPropagate();
+                if (isDeformable) {
+                        int xx = x, yy = y;
+                        float ofsX = 0, ofsY = 0;
+
+                        if (x == param.axisPoints[0].length - 1) {
+                            xx = x - 1;
+                            ofsX = 1;
+                        }
+                        if (y == param.axisPoints[1].length - 1) {
+                            yy = y - 1;
+                            ofsY = 1;
+                        }
+
+                        applyTranslation(drawable, param, vec2u(xx, yy), vec2(ofsX, ofsY));
+                        drawable.transformChanged;
+
+                    auto vertices = drawable.vertices;
+                    mat4 matrix = drawable.transform.matrix;
+
+                    auto nodeBinding = cast(DeformationParameterBinding)param.getOrAddBinding(node, "deform");
+                    auto nodeDeform = nodeBinding.values[x][y].vertexOffsets.dup;
+                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren(node, vertices, nodeDeform, &matrix);
+                    if (filterResult[0] !is null) {
+                        nodeBinding.values[x][y].vertexOffsets = filterResult[0];
+                        nodeBinding.getIsSet()[x][y] = true;
+                    }
+                } else if (transferCondition() && !isComposite) {
+                    auto vertices = [node.localTransform.translation.xy];
+                    mat4 matrix = node.parent? node.parent.transform.matrix: mat4.identity;
+
+                    auto nodeBindingX = cast(ValueParameterBinding)param.getOrAddBinding(node, "transform.t.x");
+                    auto nodeBindingY = cast(ValueParameterBinding)param.getOrAddBinding(node, "transform.t.y");
+                    auto nodeDeform = [node.offsetTransform.translation.xy];
+                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren(node, vertices, nodeDeform, &matrix);
+                    if (filterResult[0] !is null) {
+                        nodeBindingX.values[x][y] += filterResult[0][0].x;
+                        nodeBindingY.values[x][y] += filterResult[0][0].y;
+                        nodeBindingX.getIsSet()[x][y] = true;
+                        nodeBindingY.getIsSet()[x][y] = true;
+                    }
+
+                }
+                if (mustPropagate) {
+                    foreach (child; node.children) {
+                        transferChildren(child, x, y);
+                    }
+                }
+            }
+
+            void resetOffset(Node node) {
+                node.offsetTransform.clear();
+                node.offsetSort = 0;
+                node.transformChanged();
+                foreach (child; node.children) {
+                    resetOffset(child);
+                }
+            }
+
+
+            if  (auto binding = param.getBinding(this, "deform")) {
+
+                auto deformBinding = cast(DeformationParameterBinding)binding;
+                assert(deformBinding !is null);
+                Node target = deformBinding.targetNode;
+
+                for (int x = 0; x < param.axisPoints[0].length; x ++) {
+                    for (int y = 0; y < param.axisPoints[1].length; y ++) {
+
+                        resetOffset(puppet.root);
+
+                        vec2[] deformation;
+                        if (deformBinding.isSet_[x][y])
+                            deformation = deformBinding.values[x][y].vertexOffsets;
+                        else {
+                            bool rightMost  = x == param.axisPoints[0].length - 1;
+                            bool bottomMost = y == param.axisPoints[1].length - 1;
+                            deformation = deformBinding.interpolate(vec2u(rightMost? x - 1: x, bottomMost? y - 1: y), vec2(rightMost? 1: 0, bottomMost? 1:0)).vertexOffsets;
+                        }
+                        prepare(deformation);
+
+                        foreach (child; children) {
+                            transferChildren(child, x, y);
+                        }
+                    }
+                }
+                param.removeBinding(binding);
+            }
+
+        }
     }
 }

--- a/source/nijilive/core/nodes/filter.d
+++ b/source/nijilive/core/nodes/filter.d
@@ -32,7 +32,7 @@ mixin template NodeFilterMixin() {
         children_ref.length = 0;
     }
 
-    void _applyDeformToChildren(Node.Filter filterChildren, void delegate(vec2[]) prepare, bool delegate() transferCondition, Parameter[] params) {
+    void _applyDeformToChildren(Node.Filter filterChildren, void delegate(vec2[]) update, bool delegate() transferCondition, Parameter[] params) {
         foreach (param; params) {
             ParameterBinding[Resource][string] trsBindings;
             void extractTRSBindings(Parameter param) {
@@ -134,7 +134,7 @@ mixin template NodeFilterMixin() {
                             bool bottomMost = y == param.axisPoints[1].length - 1;
                             deformation = deformBinding.interpolate(vec2u(rightMost? x - 1: x, bottomMost? y - 1: y), vec2(rightMost? 1: 0, bottomMost? 1:0)).vertexOffsets;
                         }
-                        prepare(deformation);
+                        update(deformation);
 
                         foreach (child; children) {
                             transferChildren(child, x, y);

--- a/source/nijilive/core/nodes/filter.d
+++ b/source/nijilive/core/nodes/filter.d
@@ -1,0 +1,31 @@
+module nijilive.core.nodes.filter;
+import nijilive.core.nodes;
+import nijilive.core.nodes.utils;
+
+interface NodeFilter {
+    void captureTarget(Node target);
+    void releaseTarget(Node target);
+    void dispose();
+}
+
+mixin template NodeFilterMixin() {
+    override
+    void captureTarget(Node target) {
+        children_ref ~= target;
+        setupChild(target);
+    }
+
+    override
+    void releaseTarget(Node target) {
+        releaseChild(target);
+        children_ref = children_ref.removeByValue(target);
+    }
+
+    override
+    void dispose() {
+        foreach (t; children) {
+            releaseChild(t);
+        }
+        children_ref.length = 0;
+    }
+}

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -45,7 +45,9 @@ struct Triangle{
     children of this node
 */
 @TypeId("MeshGroup")
-class MeshGroup : Drawable {
+class MeshGroup : Drawable, NodeFilter {
+    mixin NodeFilterMixin;
+
 protected:
     ushort[] bitMask;
     vec4 bounds;

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -350,130 +350,27 @@ public:
         forwardMatrix = transform.matrix;
         inverseMatrix = globalTransform.matrix.inverse;
 
-
-        foreach (param; params) {
-            ParameterBinding[Resource][string] trsBindings;
-            void extractTRSBindings(Parameter param) {
-                foreach (binding; param.bindings) {
-                    trsBindings[binding.getTarget.name][binding.getTarget.target] = binding;
-                }
-            } 
-            extractTRSBindings(param);
-
-            void applyTranslation(Node node, Parameter param, vec2u keypoint, vec2 ofs) {
-                foreach (name; ["t.x", "t.y", "r.z", "s.x", "s.y"].map!((x)=> "transform.%s".format(x))) {
-                    if (name in trsBindings && node in trsBindings[name]) {
-                        trsBindings[name][node].apply(keypoint, ofs);
-                    }
-                }
+        void prepare(vec2[] deformation) {
+            transformedVertices.length = vertices.length;
+            foreach(i, vertex; vertices) {
+                transformedVertices[i] = vertex + deformation[i];
             }
-
-            void transferChildren(Node node, int x, int y) {
-                auto drawable = cast(Deformable)node;
-                auto composite = cast(Composite)node;
-                bool isDeformable = drawable !is null;
-                bool isComposite = composite !is null && composite.propagateMeshGroup;
-                bool mustPropagate = node.mustPropagate();
-                if (isDeformable) {
-                        int xx = x, yy = y;
-                        float ofsX = 0, ofsY = 0;
-
-                        if (x == param.axisPoints[0].length - 1) {
-                            xx = x - 1;
-                            ofsX = 1;
-                        }
-                        if (y == param.axisPoints[1].length - 1) {
-                            yy = y - 1;
-                            ofsY = 1;
-                        }
-
-                        applyTranslation(drawable, param, vec2u(xx, yy), vec2(ofsX, ofsY));
-                        drawable.transformChanged;
-
-                    auto vertices = drawable.vertices;
-                    mat4 matrix = drawable.transform.matrix;
-
-                    auto nodeBinding = cast(DeformationParameterBinding)param.getOrAddBinding(node, "deform");
-                    auto nodeDeform = nodeBinding.values[x][y].vertexOffsets.dup;
-                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren(node, vertices, nodeDeform, &matrix);
-                    if (filterResult[0] !is null) {
-                        nodeBinding.values[x][y].vertexOffsets = filterResult[0];
-                        nodeBinding.getIsSet()[x][y] = true;
-                    }
-                } else if (translateChildren && !isComposite) {
-                    auto vertices = [node.localTransform.translation.xy];
-                    mat4 matrix = node.parent? node.parent.transform.matrix: mat4.identity;
-
-                    auto nodeBindingX = cast(ValueParameterBinding)param.getOrAddBinding(node, "transform.t.x");
-                    auto nodeBindingY = cast(ValueParameterBinding)param.getOrAddBinding(node, "transform.t.y");
-                    auto nodeDeform = [node.offsetTransform.translation.xy];
-                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren(node, vertices, nodeDeform, &matrix);
-                    if (filterResult[0] !is null) {
-                        nodeBindingX.values[x][y] += filterResult[0][0].x;
-                        nodeBindingY.values[x][y] += filterResult[0][0].y;
-                        nodeBindingX.getIsSet()[x][y] = true;
-                        nodeBindingY.getIsSet()[x][y] = true;
-                    }
-
-                }
-                if (mustPropagate) {
-                    foreach (child; node.children) {
-                        transferChildren(child, x, y);
-                    }
-                }
+            foreach (index; 0..triangles.length) {
+                auto p1 = transformedVertices[data.indices[index * 3]];
+                auto p2 = transformedVertices[data.indices[index * 3 + 1]];
+                auto p3 = transformedVertices[data.indices[index * 3 + 2]];
+                triangles[index].transformMatrix = mat3([p2.x - p1.x, p3.x - p1.x, p1.x,
+                                                        p2.y - p1.y, p3.y - p1.y, p1.y,
+                                                        0, 0, 1]) * triangles[index].offsetMatrices;
             }
-
-            void resetOffset(Node node) {
-                node.offsetTransform.clear();
-                node.offsetSort = 0;
-                node.transformChanged();
-                foreach (child; node.children) {
-                    resetOffset(child);
-                }
-            }
-
-
-            if  (auto binding = param.getBinding(this, "deform")) {
-
-                auto deformBinding = cast(DeformationParameterBinding)binding;
-                assert(deformBinding !is null);
-                Node target = deformBinding.targetNode;
-
-                for (int x = 0; x < param.axisPoints[0].length; x ++) {
-                    for (int y = 0; y < param.axisPoints[1].length; y ++) {
-
-                        resetOffset(puppet.root);
-
-                        vec2[] deformation;
-                        if (deformBinding.isSet_[x][y])
-                            deformation = deformBinding.values[x][y].vertexOffsets;
-                        else {
-                            bool rightMost  = x == param.axisPoints[0].length - 1;
-                            bool bottomMost = y == param.axisPoints[1].length - 1;
-                            deformation = deformBinding.interpolate(vec2u(rightMost? x - 1: x, bottomMost? y - 1: y), vec2(rightMost? 1: 0, bottomMost? 1:0)).vertexOffsets;
-                        }
-                        transformedVertices.length = vertices.length;
-                        foreach(i, vertex; vertices) {
-                            transformedVertices[i] = vertex + deformation[i];
-                        }
-                        foreach (index; 0..triangles.length) {
-                            auto p1 = transformedVertices[data.indices[index * 3]];
-                            auto p2 = transformedVertices[data.indices[index * 3 + 1]];
-                            auto p3 = transformedVertices[data.indices[index * 3 + 2]];
-                            triangles[index].transformMatrix = mat3([p2.x - p1.x, p3.x - p1.x, p1.x,
-                                                                    p2.y - p1.y, p3.y - p1.y, p1.y,
-                                                                    0, 0, 1]) * triangles[index].offsetMatrices;
-                        }
-
-                        foreach (child; children) {
-                            transferChildren(child, x, y);
-                        }
-                    }
-                }
-                param.removeBinding(binding);
-            }
-
         }
+
+        bool transfer() {
+            return translateChildren;
+        }
+
+        _applyDeformToChildren(&filterChildren, &prepare, &transfer, params);
+
         data.indices.length = 0;
         data.vertices.length = 0;
         data.uvs.length = 0;

--- a/source/nijilive/core/nodes/package.d
+++ b/source/nijilive/core/nodes/package.d
@@ -24,6 +24,7 @@ public import nijilive.core.nodes.meshgroup;
 public import nijilive.core.nodes.drivers; 
 public import nijilive.core.nodes.composite.dcomposite;
 public import nijilive.core.nodes.deformer.path;
+public import nijilive.core.nodes.filter;
 import nijilive.core.nodes.utils;
 import std.typecons: tuple, Tuple;
 import std.algorithm.searching;
@@ -95,7 +96,7 @@ private:
 
     @Ignore
     Node parent_;
-    
+
     @Ignore
     Node[] children_;
     

--- a/source/nijilive/core/nodes/package.d
+++ b/source/nijilive/core/nodes/package.d
@@ -210,8 +210,9 @@ protected:
     }
     MatrixHolder overrideTransformMatrix = null;
 
-    Tuple!(vec2[], mat4*, bool) delegate(Node, vec2[], vec2[], mat4*)[] preProcessFilters;
-    Tuple!(vec2[], mat4*, bool) delegate(Node, vec2[], vec2[], mat4*)[] postProcessFilters;
+    alias Filter = Tuple!(vec2[], mat4*, bool) delegate(Node, vec2[], vec2[], mat4*);
+    Filter[] preProcessFilters;
+    Filter[] postProcessFilters;
 
     import std.stdio;
     void preProcess() {

--- a/source/nijilive/core/puppet.d
+++ b/source/nijilive/core/puppet.d
@@ -610,7 +610,7 @@ public:
     /**
         Finds nodes based on their type
     */
-    final T[] findNodesType(T)(Node n) if (is(T : Node)) {
+    final T[] findNodesType(T)(Node n) if (is(T : Node) || is (T : NodeFilter)) {
         T[] nodes;
 
         if (T item = cast(T)n) {
@@ -871,7 +871,7 @@ public:
     }
 
     void applyDeformToChildren() {
-        auto nodes = findNodesType!MeshGroup(root);
+        auto nodes = findNodesType!NodeFilter(root);
         foreach (node; nodes) {
             node.applyDeformToChildren(parameters);
         }


### PR DESCRIPTION
NodeFilter interface is added.
This interface specifies that the class can:
 - capture and release some Node object, and deform them.
 - has applyDeformToChildren method, which reflect deformation of the Filter to deformation of target object.
 
Also, export to INP file also optimizes the deformation by PathDeformer.