### PR TITLE
Tentative implementation to fix improper filter postProcess filters

### DIFF
--- a/source/nijilive/core/nodes/composite/dcomposite.d
+++ b/source/nijilive/core/nodes/composite/dcomposite.d
@@ -438,11 +438,11 @@ public:
     }
 
     override
-    void postProcess() {
+    void postProcess(int id = 0) {
         if (!autoResizedMesh) {
-            super.postProcess();
+            super.postProcess(id);
         } else {
-            Node.postProcess();
+            Node.postProcess(id);
         }
     }
 

--- a/source/nijilive/core/nodes/composite/package.d
+++ b/source/nijilive/core/nodes/composite/package.d
@@ -342,12 +342,12 @@ protected:
     }
 
     override
-    void postProcess() {
+    void postProcess(int id = 0) {
         if (delegated) {
-            delegated.postProcess();
+            delegated.postProcess(id);
         }
         if (!propagateMeshGroup)
-            Node.postProcess();
+            Node.postProcess(id);
     }
 
 public:

--- a/source/nijilive/core/nodes/deformable.d
+++ b/source/nijilive/core/nodes/deformable.d
@@ -98,7 +98,13 @@ public:
         preProcess();
         deformStack.update();
         super.update();
-        this.updateDeform();
+    }
+
+    override
+    void endUpdate(int id = 0) {
+        postProcess(id);
+        updateDeform();
+        super.endUpdate(id);
     }
 
     void updateDeform() {
@@ -108,7 +114,6 @@ public:
                 deformation[i] = vec2(0, 0);
             }
         }
-        postProcess();
     }
 
     override
@@ -118,7 +123,7 @@ public:
         preProcessed = true;
         foreach (preProcessFilter; preProcessFilters) {
             mat4 matrix = (overrideTransformMatrix !is null)? overrideTransformMatrix.matrix: this.transform.matrix;
-            auto filterResult = preProcessFilter(this, vertices, deformation, &matrix);
+            auto filterResult = preProcessFilter[1](this, vertices, deformation, &matrix);
             if (filterResult[0] !is null) {
                 deformation = filterResult[0];
             } 
@@ -133,13 +138,14 @@ public:
     }
 
     override
-    void postProcess() {
-        if (postProcessed)
+    void postProcess(int id = 0) {
+        if (postProcessed >= id)
             return;
-        postProcessed = true;
+        postProcessed = id;
         foreach (postProcessFilter; postProcessFilters) {
+            if (postProcessFilter[0] != id) continue;
             mat4 matrix = (overrideTransformMatrix !is null)? overrideTransformMatrix.matrix: this.transform.matrix;
-            auto filterResult = postProcessFilter(this, vertices, deformation, &matrix);
+            auto filterResult = postProcessFilter[1](this, vertices, deformation, &matrix);
             if (filterResult[0] !is null) {
                 deformation = filterResult[0];
             } 

--- a/source/nijilive/core/nodes/deformer/path.d
+++ b/source/nijilive/core/nodes/deformer/path.d
@@ -283,10 +283,10 @@ public:
         bool isDrawable = drawable !is null;
         if (isDrawable) {
             cacheClosestPoints(node);
-            node.preProcessFilters  = node.preProcessFilters.upsert!(Node.Filter, prepend)(&deformChildren);
+            node.preProcessFilters  = node.preProcessFilters.upsert!(Node.Filter, prepend)(tuple(1, &deformChildren));
         } else {
             meshCaches.remove(node); 
-            node.preProcessFilters  = node.preProcessFilters.removeByValue(&deformChildren);
+            node.preProcessFilters  = node.preProcessFilters.removeByValue(tuple(1, &deformChildren));
         }
         return true;
     }
@@ -310,7 +310,7 @@ public:
     }
 
     bool releaseChildNoRecurse(Node node) {
-        node.preProcessFilters = node.preProcessFilters.removeByValue(&deformChildren);
+        node.preProcessFilters = node.preProcessFilters.removeByValue(tuple(1, &deformChildren));
         return true;
     }
 
@@ -428,7 +428,7 @@ public:
 
         bool transfer() { return false; }
 
-        _applyDeformToChildren(&deformChildren, &update, &transfer, params, recursive);
+        _applyDeformToChildren(tuple(1, &deformChildren), &update, &transfer, params, recursive);
         physicsOnly = true;
         rebuffer([]);
     }

--- a/source/nijilive/core/nodes/drivers/simplephysics.d
+++ b/source/nijilive/core/nodes/drivers/simplephysics.d
@@ -429,11 +429,11 @@ public:
     }
 
     override
-    void postProcess() { 
+    void postProcess(int id = 0) { 
         auto prevPos = (localOnly ? 
             (vec4(transformLocal.translation, 1)) : 
             (transform.matrix * vec4(0, 0, 0, 1))).xy;
-        super.postProcess(); 
+        super.postProcess(id); 
         auto anchorPos = (localOnly ? 
             (vec4(transformLocal.translation, 1)) : 
             (transform.matrix * vec4(0, 0, 0, 1))).xy;

--- a/source/nijilive/core/nodes/filter.d
+++ b/source/nijilive/core/nodes/filter.d
@@ -66,7 +66,7 @@ mixin template NodeFilterMixin() {
 
                     auto nodeBinding = cast(DeformationParameterBinding)param.getOrAddBinding(node, "deform");
                     auto nodeDeform = nodeBinding.values[x][y].vertexOffsets.dup;
-                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren(node, vertices, nodeDeform, &matrix);
+                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren[1](node, vertices, nodeDeform, &matrix);
                     if (filterResult[0] !is null) {
                         nodeBinding.values[x][y].vertexOffsets = filterResult[0];
                         nodeBinding.getIsSet()[x][y] = true;
@@ -78,7 +78,7 @@ mixin template NodeFilterMixin() {
                     auto nodeBindingX = cast(ValueParameterBinding)param.getOrAddBinding(node, "transform.t.x");
                     auto nodeBindingY = cast(ValueParameterBinding)param.getOrAddBinding(node, "transform.t.y");
                     auto nodeDeform = [node.offsetTransform.translation.xy];
-                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren(node, vertices, nodeDeform, &matrix);
+                    Tuple!(vec2[], mat4*, bool) filterResult = filterChildren[1](node, vertices, nodeDeform, &matrix);
                     if (filterResult[0] !is null) {
                         nodeBindingX.values[x][y] += filterResult[0][0].x;
                         nodeBindingY.values[x][y] += filterResult[0][0].y;

--- a/source/nijilive/core/nodes/meshgroup/package.d
+++ b/source/nijilive/core/nodes/meshgroup/package.d
@@ -68,8 +68,8 @@ protected:
     }
 
     override
-    void postProcess() {
-        super.preProcess();
+    void postProcess(int id = 0) {
+        super.postProcess(id);
     }
 
 public:
@@ -102,19 +102,14 @@ public:
                 index = bit - 1;
             }
             vec2 newPos = (index < 0)? cVertex: (triangles[index].transformMatrix * vec3(cVertex, 1)).xy;
-            if (!dynamic) {
-                mat4 inv = centerMatrix.inverse;
-                inv[0][3] = 0;
-                inv[1][3] = 0;
-                inv[2][3] = 0;
-                origDeformation[i] += (inv * vec4(newPos - cVertex, 0, 1)).xy;
-            } else
-                origDeformation[i] = newPos - origVertices[i];
+            mat4 inv = centerMatrix.inverse;
+            inv[0][3] = 0;
+            inv[1][3] = 0;
+            inv[2][3] = 0;
+            origDeformation[i] += (inv * vec4(newPos - cVertex, 0, 1)).xy;
         }
 
-        if (!dynamic)
-            return tuple(origDeformation, cast(mat4*)null, changed);
-        return tuple(origDeformation, &forwardMatrix, changed);
+        return tuple(origDeformation, cast(mat4*)null, changed);
     }
 
     /**
@@ -146,7 +141,6 @@ public:
         }
 
         Node.update();
-        this.updateDeform();
    }
 
     override
@@ -293,15 +287,15 @@ public:
         bool isDeformable = drawable !is null;
         if (translateChildren || isDeformable) {
             if (isDeformable && dynamic) {
-                node.preProcessFilters  = node.preProcessFilters.removeByValue(&filterChildren);
-                node.postProcessFilters = node.postProcessFilters.upsert!(Node.Filter, prepend)(&filterChildren);
+                node.preProcessFilters  = node.preProcessFilters.removeByValue(tuple(0, &filterChildren));
+                node.postProcessFilters = node.postProcessFilters.upsert!(Node.Filter, prepend)(tuple(0, &filterChildren));
             } else {
-                node.preProcessFilters  = node.preProcessFilters.upsert!(Node.Filter, prepend)(&filterChildren);
-                node.postProcessFilters = node.postProcessFilters.removeByValue(&filterChildren);
+                node.preProcessFilters  = node.preProcessFilters.upsert!(Node.Filter, prepend)(tuple(0, &filterChildren));
+                node.postProcessFilters = node.postProcessFilters.removeByValue(tuple(0, &filterChildren));
             }
         } else {
-            node.preProcessFilters  = node.preProcessFilters.removeByValue(&filterChildren);
-            node.postProcessFilters = node.postProcessFilters.removeByValue(&filterChildren);
+            node.preProcessFilters  = node.preProcessFilters.removeByValue(tuple(0, &filterChildren));
+            node.postProcessFilters = node.postProcessFilters.removeByValue(tuple(0, &filterChildren));
         }
         return false;
      }
@@ -329,8 +323,8 @@ public:
 
 
     bool releaseChildNoRecurse(Node node) {
-        node.preProcessFilters = node.preProcessFilters.removeByValue(&this.filterChildren);
-        node.postProcessFilters = node.postProcessFilters.removeByValue(&this.filterChildren);
+        node.preProcessFilters = node.preProcessFilters.removeByValue(tuple(0, &this.filterChildren));
+        node.postProcessFilters = node.postProcessFilters.removeByValue(tuple(0, &this.filterChildren));
         return false;
     }
 
@@ -393,7 +387,7 @@ public:
             return translateChildren;
         }
 
-        _applyDeformToChildren(&filterChildren, &update, &transfer, params, recursive);
+        _applyDeformToChildren(tuple(0, &filterChildren), &update, &transfer, params, recursive);
 
         data.indices.length = 0;
         data.vertices.length = 0;

--- a/source/nijilive/core/puppet.d
+++ b/source/nijilive/core/puppet.d
@@ -465,7 +465,9 @@ public:
         // Update nodes
         actualRoot.update();
 
-        actualRoot.endUpdate();
+        foreach (id; [0, 1, 2, -1]) {
+            actualRoot.endUpdate(id);
+        }
     }
 
     /**


### PR DESCRIPTION
There were two problems around MeshGroup.

1. Dynamic mode cannot allocate children in the right place.
   This happened because dynamic mode gives complex transform matrix in preProcess / postProcess filter.
   This patch disable filters to return null matrix (same as static mode.)

2. Welding is not applied properly when they were used with MeshGroup.
   This happened because application order of postProcess is incorrect.
   This patch force filters to specifies the priority to apply as postProcess filter.