### PR TITLE
Enable blendmode fallback configurable for buggy OpenGL drivers.

### DIFF
--- a/source/nijilive/core/nodes/common.d
+++ b/source/nijilive/core/nodes/common.d
@@ -104,7 +104,7 @@ private {
 /**
     Whether a multi-stage rendering pass should be used for blending
 */
-bool nlUseMultistageBlending(BlendMode blendingMode) {
+bool inUseMultistageBlending(BlendMode blendingMode) {
     if (inForceTripleBufferFallback) return false;
     switch(blendingMode) {
         case BlendMode.Normal,
@@ -120,7 +120,7 @@ bool nlUseMultistageBlending(BlendMode blendingMode) {
     }
 }
 
-void nlInitBlending() {
+void inInitBlending() {
     inForceTripleBufferFallback = inDefaultTripleBufferFallback;
     inAdvancedBlendingAvailable = hasKHRBlendEquationAdvanced;
     inAdvancedBlendingCoherentAvailable = hasKHRBlendEquationAdvancedCoherent;
@@ -245,7 +245,7 @@ enum BlendMode {
     SliceFromLower
 }
 
-bool nlIsAdvancedBlendMode(BlendMode mode) {
+bool inIsAdvancedBlendMode(BlendMode mode) {
     if (!inAdvancedBlending) return false;
     switch(mode) {
         case BlendMode.Multiply:
@@ -267,7 +267,7 @@ bool nlIsAdvancedBlendMode(BlendMode mode) {
     }
 }
 
-void nlSetBlendMode(BlendMode blendingMode, bool legacyOnly=false) {
+void inSetBlendMode(BlendMode blendingMode, bool legacyOnly=false) {
     if (!inAdvancedBlending || legacyOnly) inSetBlendModeLegacy(blendingMode);
     else switch(blendingMode) {
         case BlendMode.Multiply: glBlendEquation(GL_MULTIPLY_KHR); break;
@@ -287,8 +287,8 @@ void nlSetBlendMode(BlendMode blendingMode, bool legacyOnly=false) {
     }
 }
 
-void nlBlendModeBarrier(BlendMode mode) {
-    if (inAdvancedBlending && !inAdvancedBlendingCoherent && nlIsAdvancedBlendMode(mode)) 
+void inBlendModeBarrier(BlendMode mode) {
+    if (inAdvancedBlending && !inAdvancedBlendingCoherent && inIsAdvancedBlendMode(mode)) 
         glBlendBarrierKHR();
 }
 

--- a/source/nijilive/core/nodes/common.d
+++ b/source/nijilive/core/nodes/common.d
@@ -120,6 +120,10 @@ bool inUseMultistageBlending(BlendMode blendingMode) {
     }
 }
 
+void nlApplyBlendingCapabilities() {
+    inApplyBlendingCapabilities();
+}
+
 void inInitBlending() {
     inForceTripleBufferFallback = inDefaultTripleBufferFallback;
     inAdvancedBlendingAvailable = hasKHRBlendEquationAdvanced;

--- a/source/nijilive/core/nodes/composite/package.d
+++ b/source/nijilive/core/nodes/composite/package.d
@@ -175,7 +175,7 @@ private:
         if (!offsetScreenTint.y.isNaN) clampedColor.y = clamp(screenTint.y+offsetScreenTint.y, 0, 1);
         if (!offsetScreenTint.z.isNaN) clampedColor.z = clamp(screenTint.z+offsetScreenTint.z, 0, 1);
         cShader.setUniform(gScreenColor, clampedColor);
-        inSetBlendMode(blendingMode, true);
+        nlSetBlendMode(blendingMode, true);
 
         // Enable points array
         glEnableVertexAttribArray(0);

--- a/source/nijilive/core/nodes/composite/package.d
+++ b/source/nijilive/core/nodes/composite/package.d
@@ -175,7 +175,7 @@ private:
         if (!offsetScreenTint.y.isNaN) clampedColor.y = clamp(screenTint.y+offsetScreenTint.y, 0, 1);
         if (!offsetScreenTint.z.isNaN) clampedColor.z = clamp(screenTint.z+offsetScreenTint.z, 0, 1);
         cShader.setUniform(gScreenColor, clampedColor);
-        nlSetBlendMode(blendingMode, true);
+        inSetBlendMode(blendingMode, true);
 
         // Enable points array
         glEnableVertexAttribArray(0);

--- a/source/nijilive/core/nodes/part/package.d
+++ b/source/nijilive/core/nodes/part/package.d
@@ -222,7 +222,7 @@ private:
                 partShaderStage1.setUniform(partShaderStage1.getUniformLocation("albedo"), 0);
                 partShaderStage1.setUniform(gs1MultColor, clampedTint);
                 partShaderStage1.setUniform(gs1ScreenColor, clampedScreen);
-                inSetBlendMode(blendingMode, false);
+                nlSetBlendMode(blendingMode, false);
                 break;
             case 1:
 
@@ -241,7 +241,7 @@ private:
                 // These can be reused from stage 2
                 partShaderStage1.setUniform(gs2MultColor, clampedTint);
                 partShaderStage1.setUniform(gs2ScreenColor, clampedScreen);
-                inSetBlendMode(blendingMode, true);
+                nlSetBlendMode(blendingMode, true);
                 break;
             case 2:
 
@@ -269,7 +269,7 @@ private:
                 if (!offsetScreenTint.y.isNaN) clampedColor.y = clamp(screenTint.y+offsetScreenTint.y, 0, 1);
                 if (!offsetScreenTint.z.isNaN) clampedColor.z = clamp(screenTint.z+offsetScreenTint.z, 0, 1);
                 partShader.setUniform(gScreenColor, clampedColor);
-                inSetBlendMode(blendingMode, true);
+                nlSetBlendMode(blendingMode, true);
                 break;
             default: return;
         }
@@ -303,7 +303,7 @@ private:
 
         static if (advanced) {
             // Blending barrier
-            inBlendModeBarrier(mode);
+            nlBlendModeBarrier(mode);
         }
     }
 
@@ -357,7 +357,7 @@ protected:
 
             bool hasEmissionOrBumpmap = (textures[1] || textures[2]);
 
-            if (inUseMultistageBlending(blendingMode)) {
+            if (nlUseMultistageBlending(blendingMode)) {
 
                 // TODO: Detect if this Part is NOT in a composite,
                 // If so, we can relatively safely assume that we may skip stage 1.
@@ -370,7 +370,7 @@ protected:
                     renderStage!false(blendingMode);
                 }
             } else {
-                 version(OSX) {
+                 if (nlIsTripleBufferFallbackEnabled()) {
                      auto blendShader = inGetBlendShader(blendingMode);
                      if (blendShader) {
                          GLint previous_draw_fbo;

--- a/source/nijilive/core/nodes/part/package.d
+++ b/source/nijilive/core/nodes/part/package.d
@@ -222,7 +222,7 @@ private:
                 partShaderStage1.setUniform(partShaderStage1.getUniformLocation("albedo"), 0);
                 partShaderStage1.setUniform(gs1MultColor, clampedTint);
                 partShaderStage1.setUniform(gs1ScreenColor, clampedScreen);
-                nlSetBlendMode(blendingMode, false);
+                inSetBlendMode(blendingMode, false);
                 break;
             case 1:
 
@@ -241,7 +241,7 @@ private:
                 // These can be reused from stage 2
                 partShaderStage1.setUniform(gs2MultColor, clampedTint);
                 partShaderStage1.setUniform(gs2ScreenColor, clampedScreen);
-                nlSetBlendMode(blendingMode, true);
+                inSetBlendMode(blendingMode, true);
                 break;
             case 2:
 
@@ -269,7 +269,7 @@ private:
                 if (!offsetScreenTint.y.isNaN) clampedColor.y = clamp(screenTint.y+offsetScreenTint.y, 0, 1);
                 if (!offsetScreenTint.z.isNaN) clampedColor.z = clamp(screenTint.z+offsetScreenTint.z, 0, 1);
                 partShader.setUniform(gScreenColor, clampedColor);
-                nlSetBlendMode(blendingMode, true);
+                inSetBlendMode(blendingMode, true);
                 break;
             default: return;
         }
@@ -303,7 +303,7 @@ private:
 
         static if (advanced) {
             // Blending barrier
-            nlBlendModeBarrier(mode);
+            inBlendModeBarrier(mode);
         }
     }
 
@@ -357,7 +357,7 @@ protected:
 
             bool hasEmissionOrBumpmap = (textures[1] || textures[2]);
 
-            if (nlUseMultistageBlending(blendingMode)) {
+            if (inUseMultistageBlending(blendingMode)) {
 
                 // TODO: Detect if this Part is NOT in a composite,
                 // If so, we can relatively safely assume that we may skip stage 1.

--- a/source/nijilive/core/package.d
+++ b/source/nijilive/core/package.d
@@ -198,7 +198,7 @@ package(nijilive) {
         inSetViewport(640, 480);
         
         // Initialize dynamic meshes
-        nlInitBlending();
+        inInitBlending();
         inInitNodes();
         inInitDrawable();
         inInitPart();

--- a/source/nijilive/core/package.d
+++ b/source/nijilive/core/package.d
@@ -198,7 +198,7 @@ package(nijilive) {
         inSetViewport(640, 480);
         
         // Initialize dynamic meshes
-        inInitBlending();
+        nlInitBlending();
         inInitNodes();
         inInitDrawable();
         inInitPart();

--- a/source/nijilive/core/package.d
+++ b/source/nijilive/core/package.d
@@ -269,7 +269,7 @@ package(nijilive) {
             // go back to default fb
             glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-            version(OSX) {
+            if (blendShaders.length == 0) {
                 auto advancedBlendShader = new Shader(import("basic/basic.vert"), import("basic/advanced_blend.frag"));
                 BlendMode[] advancedModes = [
                     BlendMode.Multiply,


### PR DESCRIPTION
Blendmode fallback mode was introduced in MacOS in previous patch.
However, regarding buggy drivers found in addition to MacOS which doesn't support `KHR_blend_equation_advanced`, that code was converted to configurable options even for other OSes.