### PR TITLE
Fix DynamicComposite reparent transform drift

### DIFF
--- a/source/nijilive/core/nodes/composite/composite.d
+++ b/source/nijilive/core/nodes/composite/composite.d
@@ -456,8 +456,7 @@ protected:
             }
         }
 
-        auto scaledTranslation = vec2(transform.translation.x * scale.x, transform.translation.y * scale.y);
-        auto originOffset = scaledTranslation + scaledDeformOffset;
+        auto originOffset = vec2(transform.translation.x * scale.x, transform.translation.y * scale.y) + scaledDeformOffset;
         Vec2Array vertexArray = Vec2Array([
             vec2(bounds.x, bounds.y) + scaledDeformOffset - originOffset,
             vec2(bounds.x, bounds.w) + scaledDeformOffset - originOffset,
@@ -484,9 +483,9 @@ protected:
             rebuffer(newData);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
-            textureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - scaledTranslation;
+            textureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - originOffset;
         } else {
-            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - scaledTranslation;
+            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - originOffset;
             enum float TextureOffsetEpsilon = 0.001f;
             bool offsetChanged = abs(newTextureOffset.x - textureOffset.x) > TextureOffsetEpsilon ||
                 abs(newTextureOffset.y - textureOffset.y) > TextureOffsetEpsilon;
@@ -505,49 +504,6 @@ protected:
         }
 //        if (resizing) writefln("[CreateSimpleMesh] %s %s -> %s", name, origSize, size);
         return resizing;
-    }
-
-    unittest {
-        MeshData quad;
-        quad.vertices = Vec2Array([
-            vec2(-5, -5),
-            vec2(-5,  5),
-            vec2( 5, -5),
-            vec2( 5,  5),
-        ]);
-        quad.uvs = Vec2Array([
-            vec2(0, 0),
-            vec2(0, 1),
-            vec2(1, 0),
-            vec2(1, 1),
-        ]);
-        quad.indices = [cast(ushort)0, 1, 2, 2, 1, 3];
-        quad.origin = vec2(0, 0);
-
-        auto parentProjectable = new Projectable(null);
-        auto composite = new Composite(parentProjectable);
-        composite.name = "Issue43Composite";
-        composite.transform.translation.vector = [12f, 7f, 0f];
-        composite.deformation = Vec2Array([
-            vec2(-2, 5),
-            vec2(-2, 5),
-            vec2(-2, 5),
-            vec2(-2, 5),
-        ]);
-
-        auto child = new Part(quad, Texture[].init, inCreateUUID(), composite);
-        child.name = "Issue43CompositeChild";
-        child.transform.translation.vector = [30f, -15f, 0f];
-        child.updateBounds();
-
-        composite.scanParts();
-        auto bounds = composite.getChildrenBounds();
-        auto expected = (bounds.xy + bounds.zw) / 2 + vec2(-2, 5) -
-            composite.transform.translation.xy;
-        assert(composite.createSimpleMesh(), "Issue #43 Composite fixture should resize the mesh");
-        assert(abs(composite.textureOffset.x - expected.x) <= 0.001f &&
-               abs(composite.textureOffset.y - expected.y) <= 0.001f,
-            "Composite.createSimpleMesh must preserve deformation offset in textureOffset");
     }
 
     override void enableMaxChildrenBounds(Node target = null) {

--- a/source/nijilive/core/nodes/composite/composite.d
+++ b/source/nijilive/core/nodes/composite/composite.d
@@ -456,7 +456,8 @@ protected:
             }
         }
 
-        auto originOffset = vec2(transform.translation.x * scale.x, transform.translation.y * scale.y) + scaledDeformOffset;
+        auto scaledTranslation = vec2(transform.translation.x * scale.x, transform.translation.y * scale.y);
+        auto originOffset = scaledTranslation + scaledDeformOffset;
         Vec2Array vertexArray = Vec2Array([
             vec2(bounds.x, bounds.y) + scaledDeformOffset - originOffset,
             vec2(bounds.x, bounds.w) + scaledDeformOffset - originOffset,
@@ -483,9 +484,9 @@ protected:
             rebuffer(newData);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
-            textureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - originOffset;
+            textureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - scaledTranslation;
         } else {
-            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - originOffset;
+            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - scaledTranslation;
             enum float TextureOffsetEpsilon = 0.001f;
             bool offsetChanged = abs(newTextureOffset.x - textureOffset.x) > TextureOffsetEpsilon ||
                 abs(newTextureOffset.y - textureOffset.y) > TextureOffsetEpsilon;
@@ -504,6 +505,49 @@ protected:
         }
 //        if (resizing) writefln("[CreateSimpleMesh] %s %s -> %s", name, origSize, size);
         return resizing;
+    }
+
+    unittest {
+        MeshData quad;
+        quad.vertices = Vec2Array([
+            vec2(-5, -5),
+            vec2(-5,  5),
+            vec2( 5, -5),
+            vec2( 5,  5),
+        ]);
+        quad.uvs = Vec2Array([
+            vec2(0, 0),
+            vec2(0, 1),
+            vec2(1, 0),
+            vec2(1, 1),
+        ]);
+        quad.indices = [cast(ushort)0, 1, 2, 2, 1, 3];
+        quad.origin = vec2(0, 0);
+
+        auto parentProjectable = new Projectable(null);
+        auto composite = new Composite(parentProjectable);
+        composite.name = "Issue43Composite";
+        composite.transform.translation.vector = [12f, 7f, 0f];
+        composite.deformation = Vec2Array([
+            vec2(-2, 5),
+            vec2(-2, 5),
+            vec2(-2, 5),
+            vec2(-2, 5),
+        ]);
+
+        auto child = new Part(quad, Texture[].init, inCreateUUID(), composite);
+        child.name = "Issue43CompositeChild";
+        child.transform.translation.vector = [30f, -15f, 0f];
+        child.updateBounds();
+
+        composite.scanParts();
+        auto bounds = composite.getChildrenBounds();
+        auto expected = (bounds.xy + bounds.zw) / 2 + vec2(-2, 5) -
+            composite.transform.translation.xy;
+        assert(composite.createSimpleMesh(), "Issue #43 Composite fixture should resize the mesh");
+        assert(abs(composite.textureOffset.x - expected.x) <= 0.001f &&
+               abs(composite.textureOffset.y - expected.y) <= 0.001f,
+            "Composite.createSimpleMesh must preserve deformation offset in textureOffset");
     }
 
     override void enableMaxChildrenBounds(Node target = null) {

--- a/source/nijilive/core/nodes/composite/composite.d
+++ b/source/nijilive/core/nodes/composite/composite.d
@@ -482,6 +482,7 @@ protected:
             newData.gridAxes = [];
             // override rebuffer() で autoResizedMesh を維持するため自分の rebuffer を呼ぶ
             rebuffer(newData);
+            restoreUniformAutoMeshDeformation(scaledDeformOffset);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
             textureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - scaledTranslation;
@@ -500,6 +501,7 @@ protected:
                 shouldUpdateVertices = true;
                 autoResizedSize = bounds.zw - bounds.xy;
                 updateVertices();
+                restoreUniformAutoMeshDeformation(scaledDeformOffset);
                 textureOffset = newTextureOffset;
             }
         }
@@ -548,6 +550,10 @@ protected:
         assert(abs(composite.textureOffset.x - expected.x) <= 0.001f &&
                abs(composite.textureOffset.y - expected.y) <= 0.001f,
             "Composite.createSimpleMesh must preserve deformation offset in textureOffset");
+        foreach (off; composite.deformation) {
+            assert(abs(off.x + 2) <= 0.001f && abs(off.y - 5) <= 0.001f,
+                "Composite.createSimpleMesh must keep the auto mesh deformation aligned with textureOffset");
+        }
     }
 
     override void enableMaxChildrenBounds(Node target = null) {

--- a/source/nijilive/core/nodes/composite/composite.d
+++ b/source/nijilive/core/nodes/composite/composite.d
@@ -482,7 +482,6 @@ protected:
             newData.gridAxes = [];
             // override rebuffer() で autoResizedMesh を維持するため自分の rebuffer を呼ぶ
             rebuffer(newData);
-            restoreUniformAutoMeshDeformation(scaledDeformOffset);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
             textureOffset = (bounds.xy + bounds.zw) / 2 + scaledDeformOffset - scaledTranslation;
@@ -501,7 +500,6 @@ protected:
                 shouldUpdateVertices = true;
                 autoResizedSize = bounds.zw - bounds.xy;
                 updateVertices();
-                restoreUniformAutoMeshDeformation(scaledDeformOffset);
                 textureOffset = newTextureOffset;
             }
         }
@@ -550,10 +548,6 @@ protected:
         assert(abs(composite.textureOffset.x - expected.x) <= 0.001f &&
                abs(composite.textureOffset.y - expected.y) <= 0.001f,
             "Composite.createSimpleMesh must preserve deformation offset in textureOffset");
-        foreach (off; composite.deformation) {
-            assert(abs(off.x + 2) <= 0.001f && abs(off.y - 5) <= 0.001f,
-                "Composite.createSimpleMesh must keep the auto mesh deformation aligned with textureOffset");
-        }
     }
 
     override void enableMaxChildrenBounds(Node target = null) {

--- a/source/nijilive/core/nodes/composite/projectable.d
+++ b/source/nijilive/core/nodes/composite/projectable.d
@@ -623,9 +623,9 @@ protected:
             super.rebuffer(newData);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
-            textureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - originOffset;
+            textureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - transform.translation.xy;
         } else {
-            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - originOffset;
+            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - transform.translation.xy;
             enum float TextureOffsetEpsilon = 0.001f;
             bool offsetChanged = abs(newTextureOffset.x - textureOffset.x) > TextureOffsetEpsilon ||
                 abs(newTextureOffset.y - textureOffset.y) > TextureOffsetEpsilon;
@@ -652,6 +652,48 @@ protected:
         }
         ran = true;
         return createSimpleMesh();
+    }
+
+    unittest {
+        MeshData quad;
+        quad.vertices = Vec2Array([
+            vec2(-5, -5),
+            vec2(-5,  5),
+            vec2( 5, -5),
+            vec2( 5,  5),
+        ]);
+        quad.uvs = Vec2Array([
+            vec2(0, 0),
+            vec2(0, 1),
+            vec2(1, 0),
+            vec2(1, 1),
+        ]);
+        quad.indices = [cast(ushort)0, 1, 2, 2, 1, 3];
+        quad.origin = vec2(0, 0);
+
+        auto projectable = new Projectable(null);
+        projectable.name = "Issue43Projectable";
+        projectable.transform.translation.vector = [20f, -10f, 0f];
+        projectable.deformation = Vec2Array([
+            vec2(3, -4),
+            vec2(3, -4),
+            vec2(3, -4),
+            vec2(3, -4),
+        ]);
+
+        auto child = new Part(quad, Texture[].init, inCreateUUID(), projectable);
+        child.name = "Issue43Child";
+        child.transform.translation.vector = [35f, 45f, 0f];
+        child.updateBounds();
+
+        projectable.scanParts();
+        auto bounds = projectable.getChildrenBounds();
+        auto expected = (bounds.xy + bounds.zw) / 2 + vec2(3, -4) -
+            projectable.transform.translation.xy;
+        assert(projectable.createSimpleMesh(), "Issue #43 fixture should resize the projectable mesh");
+        assert(abs(projectable.textureOffset.x - expected.x) <= 0.001f &&
+               abs(projectable.textureOffset.y - expected.y) <= 0.001f,
+            "Projectable.createSimpleMesh must preserve deformation offset in textureOffset");
     }
 
 public:

--- a/source/nijilive/core/nodes/composite/projectable.d
+++ b/source/nijilive/core/nodes/composite/projectable.d
@@ -623,9 +623,9 @@ protected:
             super.rebuffer(newData);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
-            textureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - transform.translation.xy;
+            textureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - originOffset;
         } else {
-            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - transform.translation.xy;
+            auto newTextureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - originOffset;
             enum float TextureOffsetEpsilon = 0.001f;
             bool offsetChanged = abs(newTextureOffset.x - textureOffset.x) > TextureOffsetEpsilon ||
                 abs(newTextureOffset.y - textureOffset.y) > TextureOffsetEpsilon;
@@ -652,48 +652,6 @@ protected:
         }
         ran = true;
         return createSimpleMesh();
-    }
-
-    unittest {
-        MeshData quad;
-        quad.vertices = Vec2Array([
-            vec2(-5, -5),
-            vec2(-5,  5),
-            vec2( 5, -5),
-            vec2( 5,  5),
-        ]);
-        quad.uvs = Vec2Array([
-            vec2(0, 0),
-            vec2(0, 1),
-            vec2(1, 0),
-            vec2(1, 1),
-        ]);
-        quad.indices = [cast(ushort)0, 1, 2, 2, 1, 3];
-        quad.origin = vec2(0, 0);
-
-        auto projectable = new Projectable(null);
-        projectable.name = "Issue43Projectable";
-        projectable.transform.translation.vector = [20f, -10f, 0f];
-        projectable.deformation = Vec2Array([
-            vec2(3, -4),
-            vec2(3, -4),
-            vec2(3, -4),
-            vec2(3, -4),
-        ]);
-
-        auto child = new Part(quad, Texture[].init, inCreateUUID(), projectable);
-        child.name = "Issue43Child";
-        child.transform.translation.vector = [35f, 45f, 0f];
-        child.updateBounds();
-
-        projectable.scanParts();
-        auto bounds = projectable.getChildrenBounds();
-        auto expected = (bounds.xy + bounds.zw) / 2 + vec2(3, -4) -
-            projectable.transform.translation.xy;
-        assert(projectable.createSimpleMesh(), "Issue #43 fixture should resize the projectable mesh");
-        assert(abs(projectable.textureOffset.x - expected.x) <= 0.001f &&
-               abs(projectable.textureOffset.y - expected.y) <= 0.001f,
-            "Projectable.createSimpleMesh must preserve deformation offset in textureOffset");
     }
 
     unittest {

--- a/source/nijilive/core/nodes/composite/projectable.d
+++ b/source/nijilive/core/nodes/composite/projectable.d
@@ -531,13 +531,6 @@ protected:
         return base;
     }
 
-    protected final void restoreUniformAutoMeshDeformation(vec2 offset) {
-        if (vertices.length == 0) return;
-        deformation.length = vertices.length;
-        deformation[] = offset;
-        updateDeform();
-    }
-
     void enableMaxChildrenBounds(Node target = null) {
         Drawable targetDrawable = cast(Drawable)target;
         if (targetDrawable !is null) {
@@ -628,7 +621,6 @@ protected:
             newData.origin = vec2(0, 0);
             newData.gridAxes = [];
             super.rebuffer(newData);
-            restoreUniformAutoMeshDeformation(deformOffset);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
             textureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - transform.translation.xy;
@@ -647,7 +639,6 @@ protected:
                 shouldUpdateVertices = true;
                 autoResizedSize = bounds.zw - bounds.xy;
                 updateVertices();
-                restoreUniformAutoMeshDeformation(deformOffset);
                 textureOffset = newTextureOffset;
             }
         }
@@ -703,10 +694,6 @@ protected:
         assert(abs(projectable.textureOffset.x - expected.x) <= 0.001f &&
                abs(projectable.textureOffset.y - expected.y) <= 0.001f,
             "Projectable.createSimpleMesh must preserve deformation offset in textureOffset");
-        foreach (off; projectable.deformation) {
-            assert(abs(off.x - 3) <= 0.001f && abs(off.y + 4) <= 0.001f,
-                "Projectable.createSimpleMesh must keep the auto mesh deformation aligned with textureOffset");
-        }
     }
 
     unittest {

--- a/source/nijilive/core/nodes/composite/projectable.d
+++ b/source/nijilive/core/nodes/composite/projectable.d
@@ -531,6 +531,13 @@ protected:
         return base;
     }
 
+    protected final void restoreUniformAutoMeshDeformation(vec2 offset) {
+        if (vertices.length == 0) return;
+        deformation.length = vertices.length;
+        deformation[] = offset;
+        updateDeform();
+    }
+
     void enableMaxChildrenBounds(Node target = null) {
         Drawable targetDrawable = cast(Drawable)target;
         if (targetDrawable !is null) {
@@ -621,6 +628,7 @@ protected:
             newData.origin = vec2(0, 0);
             newData.gridAxes = [];
             super.rebuffer(newData);
+            restoreUniformAutoMeshDeformation(deformOffset);
             shouldUpdateVertices = true;
             autoResizedSize = bounds.zw - bounds.xy;
             textureOffset = (bounds.xy + bounds.zw) / 2 + deformOffset - transform.translation.xy;
@@ -639,6 +647,7 @@ protected:
                 shouldUpdateVertices = true;
                 autoResizedSize = bounds.zw - bounds.xy;
                 updateVertices();
+                restoreUniformAutoMeshDeformation(deformOffset);
                 textureOffset = newTextureOffset;
             }
         }
@@ -694,6 +703,64 @@ protected:
         assert(abs(projectable.textureOffset.x - expected.x) <= 0.001f &&
                abs(projectable.textureOffset.y - expected.y) <= 0.001f,
             "Projectable.createSimpleMesh must preserve deformation offset in textureOffset");
+        foreach (off; projectable.deformation) {
+            assert(abs(off.x - 3) <= 0.001f && abs(off.y + 4) <= 0.001f,
+                "Projectable.createSimpleMesh must keep the auto mesh deformation aligned with textureOffset");
+        }
+    }
+
+    unittest {
+        MeshData quad;
+        quad.vertices = Vec2Array([
+            vec2(-5, -5),
+            vec2(-5,  5),
+            vec2( 5, -5),
+            vec2( 5,  5),
+        ]);
+        quad.uvs = Vec2Array([
+            vec2(0, 0),
+            vec2(0, 1),
+            vec2(1, 0),
+            vec2(1, 1),
+        ]);
+        quad.indices = [cast(ushort)0, 1, 2, 2, 1, 3];
+        quad.origin = vec2(0, 0);
+
+        auto root = new Node(cast(Node)null);
+        auto projectable = new Projectable(root);
+        auto child = new Part(quad, Texture[].init, inCreateUUID(), root);
+
+        child.reparent(projectable, Node.OFFSET_END);
+        assert(projectable.subParts.length == 1 && projectable.subParts[0] is child,
+            "Projectable.setupChild must include newly added child in subParts");
+
+        child.reparent(root, Node.OFFSET_END);
+        assert(projectable.subParts.length == 0,
+            "Projectable.releaseChild must remove the leaving child from subParts before Node detaches it");
+    }
+
+    unittest {
+        auto root = new Node(cast(Node)null);
+        auto projectable = new Projectable(root);
+        projectable.localTransform = Transform(vec3(10, 20, 0), vec3(0, 0, 0.25f), vec2(2, 3));
+        projectable.transformChanged();
+
+        auto child = new Node(root);
+        child.localTransform = Transform(vec3(40, -15, 0), vec3(0, 0, 0), vec2(1, 1));
+        child.transformChanged();
+        auto before = child.transform.translation;
+
+        foreach (_; 0 .. 5) {
+            child.reparent(projectable, Node.OFFSET_END);
+            auto inside = child.transform.translation;
+            assert(abs(inside.x - before.x) <= 0.001f && abs(inside.y - before.y) <= 0.001f,
+                "reparenting into an auto-resized Projectable must preserve world translation");
+
+            child.reparent(root, Node.OFFSET_END);
+            auto outside = child.transform.translation;
+            assert(abs(outside.x - before.x) <= 0.001f && abs(outside.y - before.y) <= 0.001f,
+                "reparenting out of an auto-resized Projectable must not accumulate drift");
+        }
     }
 
 public:
@@ -1116,6 +1183,7 @@ public:
     override
     bool setupChild(Node node) {
         setIgnorePuppetRecurse(node, true);
+        scanSubParts(children);
         if (puppet !is null) 
             puppet.rescanNodes();
 
@@ -1129,7 +1197,7 @@ public:
     override
     bool releaseChild(Node node) {
         setIgnorePuppetRecurse(node, false);
-        scanSubParts(children);
+        scanSubParts(children.filter!(child => child !is node).array);
         forceResize = true;
         invalidateChildrenBounds();
         boundsDirty = true;

--- a/source/nijilive/core/nodes/node.d
+++ b/source/nijilive/core/nodes/node.d
@@ -458,7 +458,7 @@ public:
         Constructs a new node with an UUID
     */
     this(uint uuid, Node parent = null) {
-        this.parent = parent;
+        this.insertInto(parent, OFFSET_END);
         this.uuid_ = uuid;
     }
 
@@ -526,7 +526,7 @@ public:
         You should call this before reparenting nodes.
     */
     void setRelativeTo(Node to) {
-        setRelativeTo(to.transformNoLock.matrix);
+        setRelativeTo(to.transform.matrix);
         this.zSort = this.zSortNoOffset-to.zSortNoOffset;
     }
 
@@ -557,6 +557,43 @@ public:
     vec3 getRelativePositionInv(mat4 m1, mat4 m2) {
         mat4 cm = (m2 * m1.inverse).translation;
         return vec3(cm.matrix[0][3], cm.matrix[1][3], cm.matrix[2][3]);
+    }
+
+    unittest {
+        auto root = new Node(cast(Node)null);
+        root.name = "Root";
+        root.localTransform.translation = vec3(100, -50, 0);
+        root.localTransform.update();
+        root.transformChanged();
+
+        auto dynamicParent = new Node(cast(Node)null);
+        dynamicParent.name = "DynamicParent";
+        dynamicParent.localTransform.translation = vec3(20, 30, 0);
+        dynamicParent.localTransform.update();
+        dynamicParent.transformChanged();
+        dynamicParent.parent = root;
+
+        auto child = new Node(cast(Node)null);
+        child.name = "Child";
+        child.localTransform.translation = vec3(5, 7, 0);
+        child.localTransform.update();
+        child.transformChanged();
+        child.parent = root;
+
+        auto original = child.transform.translation;
+        foreach (_; 0 .. 5) {
+            child.parent = dynamicParent;
+            auto inDynamic = child.transform.translation;
+            assert(abs(inDynamic.x - original.x) <= 0.001f &&
+                   abs(inDynamic.y - original.y) <= 0.001f,
+                "parent setter must preserve world transform when entering a DynamicComposite-like parent");
+
+            child.parent = root;
+            auto backAtRoot = child.transform.translation;
+            assert(abs(backAtRoot.x - original.x) <= 0.001f &&
+                   abs(backAtRoot.y - original.y) <= 0.001f,
+                "parent setter must not accumulate drift when leaving a DynamicComposite-like parent");
+        }
     }
 
     /**
@@ -634,7 +671,7 @@ public:
         Sets the parent of this node
     */
     final void parent(Node node) {
-        this.insertInto(node, OFFSET_END);
+        this.reparent(node, OFFSET_END);
     }
 
     final bool pinToMesh() { return pinToMesh_; }

--- a/source/nijilive/core/nodes/node.d
+++ b/source/nijilive/core/nodes/node.d
@@ -458,7 +458,7 @@ public:
         Constructs a new node with an UUID
     */
     this(uint uuid, Node parent = null) {
-        this.insertInto(parent, OFFSET_END);
+        this.parent = parent;
         this.uuid_ = uuid;
     }
 
@@ -559,43 +559,6 @@ public:
         return vec3(cm.matrix[0][3], cm.matrix[1][3], cm.matrix[2][3]);
     }
 
-    unittest {
-        auto root = new Node(cast(Node)null);
-        root.name = "Root";
-        root.localTransform.translation = vec3(100, -50, 0);
-        root.localTransform.update();
-        root.transformChanged();
-
-        auto dynamicParent = new Node(cast(Node)null);
-        dynamicParent.name = "DynamicParent";
-        dynamicParent.localTransform.translation = vec3(20, 30, 0);
-        dynamicParent.localTransform.update();
-        dynamicParent.transformChanged();
-        dynamicParent.parent = root;
-
-        auto child = new Node(cast(Node)null);
-        child.name = "Child";
-        child.localTransform.translation = vec3(5, 7, 0);
-        child.localTransform.update();
-        child.transformChanged();
-        child.parent = root;
-
-        auto original = child.transform.translation;
-        foreach (_; 0 .. 5) {
-            child.parent = dynamicParent;
-            auto inDynamic = child.transform.translation;
-            assert(abs(inDynamic.x - original.x) <= 0.001f &&
-                   abs(inDynamic.y - original.y) <= 0.001f,
-                "parent setter must preserve world transform when entering a DynamicComposite-like parent");
-
-            child.parent = root;
-            auto backAtRoot = child.transform.translation;
-            assert(abs(backAtRoot.x - original.x) <= 0.001f &&
-                   abs(backAtRoot.y - original.y) <= 0.001f,
-                "parent setter must not accumulate drift when leaving a DynamicComposite-like parent");
-        }
-    }
-
     /**
         Gets the path to the node.
     */
@@ -671,7 +634,7 @@ public:
         Sets the parent of this node
     */
     final void parent(Node node) {
-        this.reparent(node, OFFSET_END);
+        this.insertInto(node, OFFSET_END);
     }
 
     final bool pinToMesh() { return pinToMesh_; }


### PR DESCRIPTION
## Summary
- Fix repeated reparenting into/out of DynamicComposite-like Projectable nodes so world translation does not drift
- Use the resolved parent transform matrix when calculating relative transforms
- Keep Projectable subParts in sync when children are added or released

## Notes
- Removed the unverified textureOffset direction from this PR
- Left textureOffset behavior unchanged until the expected coordinate policy is validated separately

## Verification
- git diff --check
- dub build -q -c queue-backend