### PR TITLE
Fix/physics

### DIFF
--- a/source/nijilive/core/nodes/drivers/simplephysics.d
+++ b/source/nijilive/core/nodes/drivers/simplephysics.d
@@ -213,6 +213,7 @@ class SpringPendulum : PhysicsSystem {
 private:
     vec2 bob = vec2(0, 0);
     vec2 dBob = vec2(0, 0);
+    vec2 lastValidOffPosNorm = vec2(0, 1);
 
 protected:
     override
@@ -282,13 +283,26 @@ protected:
             setD(dBob, vec2(0, 0));
             return;
         }
-        vec2 offPosNorm = offPos.normalized;
-        if (!isFiniteVec(offPosNorm)) {
-            driver.logPhysicsState("SpringPendulum:offPosNormNonFinite",
+        float offLen = offPos.length;
+        vec2 offPosNorm;
+        if (!isFinite(offLen)) {
+            driver.logPhysicsState("SpringPendulum:offLenNonFinite",
                 text("offPos=", offPos,
-                     " offPosNorm=", offPosNorm));
+                     " offLen=", offLen));
             setD(dBob, vec2(0, 0));
             return;
+        } else if (offLen <= float.epsilon) {
+            offPosNorm = isFiniteVec(lastValidOffPosNorm) ? lastValidOffPosNorm : vec2(0, 1);
+        } else {
+            offPosNorm = offPos / offLen;
+            if (!isFiniteVec(offPosNorm)) {
+                driver.logPhysicsState("SpringPendulum:offPosNormNonFinite",
+                    text("offPos=", offPos,
+                         " offPosNorm=", offPosNorm));
+                setD(dBob, vec2(0, 0));
+                return;
+            }
+            lastValidOffPosNorm = offPosNorm;
         }
 
         float lengthRatio = g / lengthVal;
@@ -313,7 +327,7 @@ protected:
             return;
         }
 
-        float dist = abs(driver.anchor.distance(bob));
+        float dist = abs(offLen);
         if (!isFinite(dist)) {
             driver.logPhysicsState("SpringPendulum:distanceInvalid",
                 text("anchor=", driver.anchor,
@@ -1001,3 +1015,17 @@ public:
 }
 
 mixin InNode!SimplePhysics;
+
+unittest {
+    auto driver = new SimplePhysics();
+    driver.modelType = PhysicsModel.SpringPendulum;
+    driver.anchor = vec2(0, 0);
+    driver.length = 0;
+    driver.reset();
+
+    driver.length = 100;
+    driver.system.tick(0.01);
+
+    assert(isFiniteVec(driver.output));
+    assert(driver.output.y > driver.anchor.y);
+}

--- a/source/nijilive/core/nodes/drivers/simplephysics.d
+++ b/source/nijilive/core/nodes/drivers/simplephysics.d
@@ -839,6 +839,12 @@ public:
     override
     void reset() {
         updateInputs();
+        offsetGravity = 1;
+        offsetLength = 0;
+        offsetFrequency = 1;
+        offsetAngleDamping = 1;
+        offsetLengthDamping = 1;
+        offsetOutputScale = vec2(1, 1);
 
         switch (modelType) {
             case PhysicsModel.Pendulum:
@@ -1028,4 +1034,18 @@ unittest {
 
     assert(isFiniteVec(driver.output));
     assert(driver.output.y > driver.anchor.y);
+}
+
+unittest {
+    auto driver = new SimplePhysics();
+    driver.modelType = PhysicsModel.SpringPendulum;
+    driver.anchor = vec2(0, 0);
+    driver.length = 100;
+    assert(driver.setValue("length", 50));
+
+    driver.reset();
+    driver.system.tick(0);
+
+    assert(isFiniteVec(driver.output));
+    assert(abs(driver.output.y - 100) <= 0.001);
 }

--- a/source/nijilive/integration/unity.d
+++ b/source/nijilive/integration/unity.d
@@ -53,6 +53,10 @@ extern(C) enum NjgRenderCommandKind : uint {
     EndMask,
 }
 
+extern(C) enum NjgQueryKind : uint {
+    Parameters = 1,
+}
+
 extern(C) struct UnityRendererConfig {
     int viewportWidth;
     int viewportHeight;
@@ -78,6 +82,8 @@ extern(C) struct NjgParameterInfo {
     vec2 defaults;
     const(char)* name;
     size_t nameLength;
+    vec2 value;
+    vec2 latestInternal;
 }
 
 extern(C) struct UnityResourceCallbacks {
@@ -863,6 +869,45 @@ extern(C) export NjgResult njgGetParameters(PuppetHandle puppetHandle,
         buffer[i].defaults = param.defaults;
         buffer[i].name = param.name.ptr;
         buffer[i].nameLength = param.name.length;
+        buffer[i].value = param.value;
+        buffer[i].latestInternal = param.latestInternal;
+    }
+    return NjgResult.Ok;
+}
+
+private void fillParameterInfo(ref NjgParameterInfo info, Parameter param) {
+    info.uuid = param.uuid;
+    info.isVec2 = param.isVec2;
+    info.min = param.min;
+    info.max = param.max;
+    info.defaults = param.defaults;
+    info.name = param.name.ptr;
+    info.nameLength = param.name.length;
+    info.value = param.value;
+    info.latestInternal = param.latestInternal;
+}
+
+extern(C) export NjgResult njgQuery(void* handle,
+                                    NjgQueryKind kind,
+                                    void* buffer,
+                                    size_t itemSize,
+                                    size_t itemCapacity,
+                                    size_t* outCount) {
+    if (kind != NjgQueryKind.Parameters) return NjgResult.InvalidArgument;
+    if (outCount is null) return NjgResult.InvalidArgument;
+    if (itemSize < NjgParameterInfo.sizeof) return NjgResult.InvalidArgument;
+    *outCount = 0;
+    if (handle is null) return NjgResult.InvalidArgument;
+    auto puppet = cast(Puppet)handle;
+    auto params = puppet.parameters;
+    *outCount = params.length;
+    if (buffer is null) return NjgResult.Ok;
+    if (itemCapacity < params.length) return NjgResult.InvalidArgument;
+
+    auto bytes = cast(ubyte*)buffer;
+    foreach (i, param; params) {
+        auto item = cast(NjgParameterInfo*)(bytes + i * itemSize);
+        fillParameterInfo(*item, param);
     }
     return NjgResult.Ok;
 }


### PR DESCRIPTION
## Summary

- Fix SimplePhysics SpringPendulum zero-length handling in nijilive.
- When `bob == anchor`, reuse the last valid spring direction instead of producing an invalid normalized vector.
- Fall back to the initial `+Y` rest direction when no previous valid direction exists.
- Add a regression unittest for recovery from a zero-length SpringPendulum state.
- This is the reverse patch from https://github.com/nijigenerate/nicxlive/pull/14

## Verification

- `dub build --config=full`
- `dub test --config=full` was attempted, but the existing unittest configuration fails outside this change due OpenGL/render_queue test compile errors.