### PR TITLE
Add parameter state query ABI

### DIFF
--- a/source/nijilive/integration/unity.d
+++ b/source/nijilive/integration/unity.d
@@ -895,13 +895,13 @@ extern(C) export NjgResult njgQuery(void* handle,
                                     size_t* outCount) {
     if (kind != NjgQueryKind.Parameters) return NjgResult.InvalidArgument;
     if (outCount is null) return NjgResult.InvalidArgument;
-    if (itemSize < NjgParameterInfo.sizeof) return NjgResult.InvalidArgument;
     *outCount = 0;
     if (handle is null) return NjgResult.InvalidArgument;
     auto puppet = cast(Puppet)handle;
     auto params = puppet.parameters;
     *outCount = params.length;
     if (buffer is null) return NjgResult.Ok;
+    if (itemSize < NjgParameterInfo.sizeof) return NjgResult.InvalidArgument;
     if (itemCapacity < params.length) return NjgResult.InvalidArgument;
 
     auto bytes = cast(ubyte*)buffer;

--- a/unity-managed/Editor/NijiliveParameterEditorWindow.cs
+++ b/unity-managed/Editor/NijiliveParameterEditorWindow.cs
@@ -88,7 +88,7 @@ namespace Nijilive.Unity.Managed.Editor
         private void DrawParameter(ParameterDescriptor p)
         {
             EditorGUILayout.LabelField($"{p.Name} ({p.Uuid})", EditorStyles.boldLabel);
-            var current = _values.TryGetValue(p.Uuid, out var val) ? val : ToVec2(p.Defaults);
+            var current = _values.TryGetValue(p.Uuid, out var val) ? val : ToVec2(p.Value);
 
             EditorGUI.BeginChangeCheck();
             if (p.IsVec2)
@@ -129,7 +129,7 @@ namespace Nijilive.Unity.Managed.Editor
             foreach (var p in _target.Puppet.GetParameters())
             {
                 _parameters.Add(p);
-                _values[p.Uuid] = ToVec2(p.Defaults);
+                _values[p.Uuid] = ToVec2(p.Value);
             }
         }
 

--- a/unity-managed/Interop/NijiliveNative.cs
+++ b/unity-managed/Interop/NijiliveNative.cs
@@ -69,6 +69,13 @@ public static class NijiliveNative
         public Vec2 Defaults;
         public IntPtr Name;
         public nuint NameLength;
+        public Vec2 Value;
+        public Vec2 LatestInternal;
+    }
+
+    public enum QueryKind : uint
+    {
+        Parameters = 1,
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -275,6 +282,9 @@ public static class NijiliveNative
 
     [DllImport(DllName, EntryPoint = "njgGetParameters", CallingConvention = CallingConvention.Cdecl)]
     internal static extern NjgResult GetParameters(IntPtr puppet, IntPtr buffer, nuint bufferLength, out nuint outCount);
+
+    [DllImport(DllName, EntryPoint = "njgQuery", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern NjgResult Query(IntPtr handle, QueryKind kind, IntPtr buffer, nuint itemSize, nuint itemCapacity, out nuint outCount);
 
     [DllImport(DllName, EntryPoint = "njgUpdateParameters", CallingConvention = CallingConvention.Cdecl)]
     internal static extern NjgResult UpdateParameters(IntPtr puppet, IntPtr updates, nuint updateCount);

--- a/unity-managed/Managed/NijiliveRenderer.cs
+++ b/unity-managed/Managed/NijiliveRenderer.cs
@@ -241,7 +241,16 @@ public sealed class Puppet : IDisposable
     {
         if (_disposed) throw new ObjectDisposedException(nameof(Puppet));
 
-        NijiliveRenderer.EnsureOk(NijiliveNative.GetParameters(Handle, IntPtr.Zero, 0, out var count), "GetParameters(count)");
+        var stride = Marshal.SizeOf<NijiliveNative.ParameterInfo>();
+        NijiliveRenderer.EnsureOk(
+            NijiliveNative.Query(
+                Handle,
+                NijiliveNative.QueryKind.Parameters,
+                IntPtr.Zero,
+                0,
+                0,
+                out var count),
+            "Query(parameters count)");
         if (count == 0) return Array.Empty<ParameterDescriptor>();
 
         var infos = new NijiliveNative.ParameterInfo[count];
@@ -249,7 +258,15 @@ public sealed class Puppet : IDisposable
         {
             fixed (NijiliveNative.ParameterInfo* ptr = infos)
             {
-                NijiliveRenderer.EnsureOk(NijiliveNative.GetParameters(Handle, (IntPtr)ptr, count, out _), "GetParameters(data)");
+                NijiliveRenderer.EnsureOk(
+                    NijiliveNative.Query(
+                        Handle,
+                        NijiliveNative.QueryKind.Parameters,
+                        (IntPtr)ptr,
+                        checked((nuint)stride),
+                        count,
+                        out _),
+                    "Query(parameters data)");
             }
         }
 
@@ -263,7 +280,9 @@ public sealed class Puppet : IDisposable
                 info.IsVec2,
                 info.Min,
                 info.Max,
-                info.Defaults));
+                info.Defaults,
+                info.Value,
+                info.LatestInternal));
         }
         return list;
     }
@@ -328,6 +347,8 @@ public sealed class NijiliveSharedBuffers
         public NijiliveNative.Vec2 Min;
         public NijiliveNative.Vec2 Max;
         public NijiliveNative.Vec2 Defaults;
+        public NijiliveNative.Vec2 Value;
+        public NijiliveNative.Vec2 LatestInternal;
 
         public ParameterDescriptor(
             uint uuid,
@@ -335,7 +356,9 @@ public sealed class NijiliveSharedBuffers
             bool isVec2,
             NijiliveNative.Vec2 min,
             NijiliveNative.Vec2 max,
-            NijiliveNative.Vec2 defaults)
+            NijiliveNative.Vec2 defaults,
+            NijiliveNative.Vec2 value,
+            NijiliveNative.Vec2 latestInternal)
         {
             Uuid = uuid;
             Name = name;
@@ -343,6 +366,8 @@ public sealed class NijiliveSharedBuffers
             Min = min;
             Max = max;
             Defaults = defaults;
+            Value = value;
+            LatestInternal = latestInternal;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add the shared `njgQuery` parameter-state ABI for parameter metadata queries
- Extend `NjgParameterInfo` with current `value` and `latestInternal` state
- Keep the ABI aligned with the nicxlive implementation in nijigenerate/nicxlive#15

## Verification
- `dub build --config=full`

## Related
- Synced with nijigenerate/nicxlive#15